### PR TITLE
Allow syntax sugar in 3-arity reg-sub function.

### DIFF
--- a/core/src/refx/alpha.cljc
+++ b/core/src/refx/alpha.cljc
@@ -86,7 +86,14 @@
   ([query-id compute-fn]
    (reg-sub query-id (constantly app-db) compute-fn))
   ([query-id input-fn compute-fn]
-   (subs/register query-id input-fn compute-fn))
+   ;; If we have a keyword, attempt parsing syntax sugar. Otherwise treat
+   ;; the input-fn as a function returning a vector of signals.
+   (if (keyword? input-fn)
+     (let [[new-input new-compute] (parse-reg-sub-sugar (list input-fn compute-fn))]
+       (subs/register query-id
+                      (or new-input (constantly app-db))
+                      new-compute))
+     (subs/register query-id input-fn compute-fn)))
   ;; re-frame compat
   ([query-id x y z & args]
    (let [[input-fn compute-fn] (parse-reg-sub-sugar (list* x y z args))]

--- a/core/src/refx/alpha.cljc
+++ b/core/src/refx/alpha.cljc
@@ -80,26 +80,23 @@
                            [qs op]))
                        [[] nil]
                        (partition-all 2 args))]
-    [(when (seq qs) (apply <- qs)) f]))
+    [(if (seq qs)
+       (apply <- qs)
+       (constantly app-db))
+     f]))
 
 (defn reg-sub
   ([query-id compute-fn]
-   (reg-sub query-id (constantly app-db) compute-fn))
+   (subs/register query-id (constantly app-db) compute-fn))
   ([query-id input-fn compute-fn]
-   ;; If we have a keyword, attempt parsing syntax sugar. Otherwise treat
-   ;; the input-fn as a function returning a vector of signals.
    (if (keyword? input-fn)
-     (let [[new-input new-compute] (parse-reg-sub-sugar (list input-fn compute-fn))]
-       (subs/register query-id
-                      (or new-input (constantly app-db))
-                      new-compute))
+     ;; If we have a keyword, attempt parsing syntax sugar.
+     (let [[input-fn compute-fn] (parse-reg-sub-sugar [input-fn compute-fn])]
+       (subs/register query-id input-fn compute-fn))
      (subs/register query-id input-fn compute-fn)))
-  ;; re-frame compat
   ([query-id x y z & args]
    (let [[input-fn compute-fn] (parse-reg-sub-sugar (list* x y z args))]
-     (if input-fn
-       (reg-sub query-id input-fn compute-fn)
-       (reg-sub query-id compute-fn)))))
+     (subs/register query-id input-fn compute-fn))))
 
 #?(:cljs
    (defn use-sub [query-v]

--- a/core/test/refx/alpha_test.cljs
+++ b/core/test/refx/alpha_test.cljs
@@ -1,0 +1,60 @@
+(ns refx.alpha-test
+  (:require [cljs.test :refer-macros [is deftest testing use-fixtures]]
+            [refx.alpha :as rf]
+            [refx.db :refer [app-db]]))
+
+(defn wipe-app-state!
+  "Clears all subscriptions in the registry together with subscription caches
+   and app database."
+  []
+  (rf/clear-sub)
+  (rf/clear-subscription-cache!)
+  (reset! app-db {}))
+
+(use-fixtures :each (fn [test-fn]
+                      (test-fn)
+                      (wipe-app-state!)))
+
+(deftest syntax-sugar-text
+  (let [store {:x 0
+               :y 1
+               :z 2}]
+    (reset! app-db store)
+    (testing "forward arrow syntax"
+      (rf/reg-sub :x :-> :x)
+      (rf/reg-sub :y :-> :y)
+      (rf/reg-sub :z :-> :z)
+      (doseq [sym (keys store)]
+        (is (= (store sym)
+               @(rf/sub [sym])))))
+    (testing "reverse arrow syntax"
+      ;; Note: the subscriptions for :x, :y, and :z are defined above.
+      (rf/reg-sub
+       :complex
+       :<- [:x]
+       :<- [:y]
+       :<- [:z]
+       :-> (partial reduce +))
+      (let [expected (reduce + (vals store))
+            actual   (rf/sub [:complex])]
+        (is (= expected @actual))))
+    (testing "explicit input function provided"
+      (rf/reg-sub
+       :complex-explicit
+       (fn [_ _]
+         [(rf/sub [:x])
+          (rf/sub [:y])
+          (rf/sub [:z])])
+       (fn [[x y z] _]
+         (+ x y z)))
+      (let [expected (reduce + (vals store))
+            actual   (rf/sub [:complex-explicit])]
+        (is (= expected @actual))))
+    (testing "special forward arrow syntax"
+      (rf/reg-sub
+       :sum
+       :=> (fn [_ & qs]
+             (reduce + qs)))
+      (let [expected (+ 1 2 3)
+            actual   (rf/sub [:sum 1 2 3])]
+        (is (= expected @actual))))))

--- a/core/test/refx/alpha_test.cljs
+++ b/core/test/refx/alpha_test.cljs
@@ -20,14 +20,14 @@
                :y 1
                :z 2}]
     (reset! app-db store)
-    (testing "forward arrow syntax"
+    (testing ":-> syntax"
       (rf/reg-sub :x :-> :x)
       (rf/reg-sub :y :-> :y)
       (rf/reg-sub :z :-> :z)
-      (doseq [sym (keys store)]
-        (is (= (store sym)
-               @(rf/sub [sym])))))
-    (testing "reverse arrow syntax"
+      (doseq [query-id (keys store)]
+        (is (= (store query-id)
+               @(rf/sub [query-id])))))
+    (testing ":<- syntax"
       ;; Note: the subscriptions for :x, :y, and :z are defined above.
       (rf/reg-sub
        :complex
@@ -35,9 +35,7 @@
        :<- [:y]
        :<- [:z]
        :-> (partial reduce +))
-      (let [expected (reduce + (vals store))
-            actual   (rf/sub [:complex])]
-        (is (= expected @actual))))
+      (is (= (reduce + (vals store)) @(rf/sub [:complex]))))
     (testing "explicit input function provided"
       (rf/reg-sub
        :complex-explicit
@@ -47,14 +45,10 @@
           (rf/sub [:z])])
        (fn [[x y z] _]
          (+ x y z)))
-      (let [expected (reduce + (vals store))
-            actual   (rf/sub [:complex-explicit])]
-        (is (= expected @actual))))
-    (testing "special forward arrow syntax"
+      (is (= (reduce + (vals store)) @(rf/sub [:complex-explicit]))))
+    (testing ":=> syntax"
       (rf/reg-sub
        :sum
        :=> (fn [_ & qs]
              (reduce + qs)))
-      (let [expected (+ 1 2 3)
-            actual   (rf/sub [:sum 1 2 3])]
-        (is (= expected @actual))))))
+      (is (= (+ 1 2 3) @(rf/sub [:sum 1 2 3]))))))


### PR DESCRIPTION
This commit introduces a fix and unit tests for `reg-sub` function. Fixes #1 