### PR TITLE
add batch update logic to subs

### DIFF
--- a/core/src/refx/effects.cljc
+++ b/core/src/refx/effects.cljc
@@ -5,7 +5,8 @@
             [refx.interop :as interop]
             [refx.log :as log]
             [refx.registry :as registry]
-            [refx.db :refer [app-db]]))
+            [refx.db :refer [app-db]]
+            [refx.subs :as subs]))
 
 (def kind :fx)
 
@@ -19,7 +20,9 @@
 
 (defn- db-effect [db]
   (when-not (identical? @app-db db)
-    (reset! app-db db)))
+    (subs/start-batch-update!)
+    (reset! app-db db)
+    (subs/end-batch-update!)))
 
 (def do-fx
   "An interceptor whose `:after` actions the contents of `:effects`. As a result,


### PR DESCRIPTION
Hi again 👋  Rather than using `next-tick` like I did in my last PR (#8), this introduce a `start-batch-update!` and an `end-batch-update!` function that can be used from the subs namespace. The default `:db` effect was updated to wrap the `reset!` call with these functions so that all the subs would be updated before the listeners are notified. This allows React to include all state changes in a single render.

Going to do some more QA with these changes on my app to confirm that it's working as desired but wanted to create the PR to gather feedback. Let me know if you'd like any changes or additions!

Closes #7 

PS: I'm in refx channel on Clojurians slack if you'd like to discuss any of this there.