### PR TITLE
batch listener notifications

### DIFF
--- a/core/src/refx/hooks.cljs
+++ b/core/src/refx/hooks.cljs
@@ -28,7 +28,7 @@
         (react/useMemo
          (fn []
            [(fn [callback]
-              (let [key {:index (swap! use-sub-counter inc)}]
+              (let [key {::subs/index (swap! use-sub-counter inc)}]
                 (subs/-add-listener sub key callback)
                 #(subs/-remove-listener sub key)))
             (fn []

--- a/core/src/refx/hooks.cljs
+++ b/core/src/refx/hooks.cljs
@@ -28,7 +28,7 @@
         (react/useMemo
          (fn []
            [(fn [callback]
-              (let [key (str "use-sub-" (swap! use-sub-counter inc))]
+              (let [key {:index (swap! use-sub-counter inc)}]
                 (subs/-add-listener sub key callback)
                 #(subs/-remove-listener sub key)))
             (fn []

--- a/core/src/refx/subs.cljc
+++ b/core/src/refx/subs.cljc
@@ -76,6 +76,38 @@
   (doseq [[_ sub] @sub-cache]
     (dispose! sub)))
 
+(defonce ^:private listeners-state
+  (atom {:counter 0 :pending (sorted-map)}))
+
+(defn- invoke-listener
+  "This function is responsible for ensuring that signal listeners
+  (from DynamicSubs) are called before triggering regular listeners
+  (eg: added via use-sub hook). Listeners are triggered in the order they
+  were registered. This function ensures that one db update will only trigger
+  a single render."
+  [listener-key listener-fn]
+  (swap! listeners-state (fn [state]
+                           (cond-> (update state :counter inc)
+                             (not (signal? listener-key))
+                             (update :pending assoc listener-key listener-fn))))
+
+  (when (signal? listener-key)
+    (listener-fn))
+
+  (interop/next-tick
+   (fn []
+     (let [listener-fns (atom nil)]
+       (swap! listeners-state (fn [state]
+                                (let [{:keys [counter pending] :as new-state}
+                                      (update state :counter dec)]
+                                  (if (zero? counter)
+                                    (do
+                                      (reset! listener-fns pending)
+                                      (assoc new-state :pending (sorted-map)))
+                                    new-state))))
+       (doseq [[_ f] @listener-fns]
+         (f))))))
+
 (deftype Listeners [^:mutable listeners]
   Object
   (empty? [_] (empty? listeners))
@@ -84,8 +116,8 @@
   (remove [_ k]
     (set! listeners (dissoc listeners k)))
   (notify [_]
-    (doseq [[_ f] listeners]
-      (f))))
+    (doseq [[k f] listeners]
+      (invoke-listener k f))))
 
 (defn- make-listeners []
   (Listeners. nil))

--- a/core/src/refx/subs.cljc
+++ b/core/src/refx/subs.cljc
@@ -77,7 +77,7 @@
     (dispose! sub)))
 
 (defonce ^:private listeners-state
-  (atom {:counter 0 :pending (sorted-map)}))
+  (atom {:counter 0 :pending (sorted-map-by :index)}))
 
 (defn- invoke-listener
   "This function is responsible for ensuring that signal listeners
@@ -103,7 +103,7 @@
                                   (if (zero? counter)
                                     (do
                                       (reset! listener-fns pending)
-                                      (assoc new-state :pending (sorted-map)))
+                                      (assoc new-state :pending (sorted-map-by :index)))
                                     new-state))))
        (doseq [[_ f] @listener-fns]
          (f))))))

--- a/core/src/refx/subs.cljc
+++ b/core/src/refx/subs.cljc
@@ -77,7 +77,9 @@
     (dispose! sub)))
 
 (defonce ^:private listeners-state
-  (atom {:counter 0 :pending (sorted-map-by :index)}))
+  (letfn [(comparator [a b]
+            (compare (:index b) (:index a)))]
+    (atom {:counter 0 :pending (sorted-map-by comparator)})))
 
 (defn- invoke-listener
   "This function is responsible for ensuring that signal listeners

--- a/core/src/refx/subs.cljc
+++ b/core/src/refx/subs.cljc
@@ -78,7 +78,7 @@
 
 (defonce ^:private listeners-state
   (letfn [(comparator [a b]
-            (compare (:index b) (:index a)))]
+            (compare (:index a) (:index b)))]
     (atom {:counter 0 :pending (sorted-map-by comparator)})))
 
 (defn- invoke-listener

--- a/core/src/refx/subs.cljc
+++ b/core/src/refx/subs.cljc
@@ -103,7 +103,7 @@
                                   (if (zero? counter)
                                     (do
                                       (reset! listener-fns pending)
-                                      (assoc new-state :pending (sorted-map-by :index)))
+                                      (update new-state :pending empty))
                                     new-state))))
        (doseq [[_ f] @listener-fns]
          (f))))))

--- a/core/test/refx/subs_test.cljs
+++ b/core/test/refx/subs_test.cljs
@@ -116,7 +116,7 @@
           sub-c (subs/sub [:c])
           sub-d (subs/sub [:d])
           listener-count (atom 0)
-          listener-calls (atom '())
+          listener-calls (atom [])
           remove-listener-fns (atom '())
           add-listener! (fn [sub]
                           (let [key {:index (swap! listener-count inc)}]
@@ -134,9 +134,9 @@
       (async done
              (js/setTimeout (fn []
                               (is (= @listener-calls
-                                     '({:index 1}
-                                       {:index 2}
-                                       {:index 3}
-                                       {:index 4})))
+                                     [{:index 1}
+                                      {:index 2}
+                                      {:index 3}
+                                      {:index 4}]))
                               (done))
                             10)))))

--- a/core/test/refx/subs_test.cljs
+++ b/core/test/refx/subs_test.cljs
@@ -104,3 +104,39 @@
                               (is (empty? @subs/sub-cache))
                               (done))
                             10)))))
+
+(deftest listener-ordering
+  (let [source (atom 0)]
+    (subs/register :a (constantly source) identity)
+    (subs/register :b (constantly source) identity)
+    (subs/register :c (constantly (subs/sub [:b (subs/sub [:a])])) identity)
+    (subs/register :d (constantly [(subs/sub [:b]) (subs/sub [:c])]) identity)
+    (let [sub-a (subs/sub [:a])
+          sub-b (subs/sub [:b])
+          sub-c (subs/sub [:c])
+          sub-d (subs/sub [:d])
+          listener-count (atom 0)
+          listener-calls (atom '())
+          remove-listener-fns (atom '())
+          add-listener! (fn [sub]
+                          (let [key {:index (swap! listener-count inc)}]
+                            (subs/-add-listener sub key #(swap! listener-calls conj key))
+                            (swap! remove-listener-fns conj #(subs/-remove-listener sub key))))
+          remove-listeners! (fn []
+                              (doseq [f @remove-listener-fns]
+                                (f)))]
+      (add-listener! sub-a)
+      (add-listener! sub-b)
+      (add-listener! sub-c)
+      (add-listener! sub-d)
+      (reset! source 1)
+      (remove-listeners!)
+      (async done
+             (js/setTimeout (fn []
+                              (is (= @listener-calls
+                                     '({:index 1}
+                                       {:index 2}
+                                       {:index 3}
+                                       {:index 4})))
+                              (done))
+                            10)))))

--- a/core/test/refx/subs_test.cljs
+++ b/core/test/refx/subs_test.cljs
@@ -119,7 +119,7 @@
           listener-calls (atom [])
           remove-listener-fns (atom '())
           add-listener! (fn [sub]
-                          (let [key {:index (swap! listener-count inc)}]
+                          (let [key {::subs/index (swap! listener-count inc)}]
                             (subs/-add-listener sub key #(swap! listener-calls conj key))
                             (swap! remove-listener-fns conj #(subs/-remove-listener sub key))))
           remove-listeners! (fn []
@@ -130,13 +130,13 @@
       (add-listener! sub-c)
       (add-listener! sub-d)
       (reset! source 1)
-      (remove-listeners!)
       (async done
              (js/setTimeout (fn []
+                              (remove-listeners!)
                               (is (= @listener-calls
-                                     [{:index 1}
-                                      {:index 2}
-                                      {:index 3}
-                                      {:index 4}]))
+                                     [{::subs/index 1}
+                                      {::subs/index 2}
+                                      {::subs/index 3}
+                                      {::subs/index 4}]))
                               (done))
                             10)))))


### PR DESCRIPTION
Hello again 👋  This PR addresses #7. I like this approach quite a bit more than my earlier approach as it's isolated to the listener implementation. With this change, I use an atom along with `interop/next-tick` to ensure that all "ui" listeners (from the use-sub hook) are triggered after values have updated (both Sub and DynamicSub updates). 

The listeners are fired in the order that they are registered (which is why I changed the key for `use-sub`). This is important because components higher in the tree (registered earlier) should have their hooks updated before further down components. An example of why this is needed is if you had a router subscribe to the current route, you'd want to make sure it's updated before downstream components are (otherwise downstream components could render, when they shouldn't, and have invalid hooks fired right before unmounting).

I've added these changes to my own refx project and it's been working great for the past week (I'm seeing improved performance when using our app 🎉).

Let me know if you'd like any changes or have any feedback!